### PR TITLE
Add `exports` to package.json to support more bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,14 @@
     "url": "https://beeno-tung.surge.sh"
   },
   "license": "BSD-2-Clause",
+  "exports": {
+    ".": {
+      "import": "./dist/index.js",
+      "require": "./dist/index.js",
+      "types": "./dist/index.d.ts",
+      "browser": "./bundle.js"
+    }
+  },
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "browser": "./bundle.js",


### PR DESCRIPTION
This PR addresses #18 by adding an `exports` field to `package.json`. It seems that `vite` will deduce the correct file to include if `exports` is present.