### PR TITLE
feature: Extend 'decompress' with a generic for the return type

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -91,7 +91,7 @@ export function decode(values: Values, key: Key) {
   return throwUnknownDataType(v)
 }
 
-export function decompress(c: Compressed) {
+export function decompress<TReturn = any>(c: Compressed): TReturn {
   const [values, root] = c
   return decode(values, root)
 }


### PR DESCRIPTION
Extend the `decompress` function with a return type `TReturn`.

Take this code as an example:
```typescript
interface IExample {
  field: string;
}

const dataToCompress: IExample = {
  field: 'value',
};

const compressed = compress(dataToCompress);

const decompressedWithoutType = decompress(compressed);
const decompressedWithType = decompress<IExample>(compressed);
```

Having a generic allows us to avoid such a scenario:
<img width="540" height="144" alt="image" src="https://github.com/user-attachments/assets/909277b3-15f5-4182-9172-3cc2d28ecd37" />

And gain such a possibility:
<img width="543" height="160" alt="image" src="https://github.com/user-attachments/assets/5a5cb958-4d6f-4625-9c62-c5b1b863641d" />

Note: I used `any` to preserve previous behaviour.