### PR TITLE
patch: optimize encoding and decoding functions

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -71,22 +71,28 @@ export function decode(values: Values, key: Key) {
     case 'number':
       return v
     case 'string':
-      const prefix = v[0] + v[1]
-      switch (prefix) {
-        case 'b|':
-          return decodeBool(v)
-        case 'o|':
-          return decodeObject(values, v)
-        case 'n|':
-        case 'N|+':
-        case 'N|-':
-        case 'N|0':
-          return decodeNum(v)
-        case 'a|':
-          return decodeArray(values, v)
-        default:
-          return decodeStr(v)
+      if (v[1] === '|') {
+        switch (v[0]) {
+          case 'b':
+            return decodeBool(v)
+          case 'o':
+            return decodeObject(values, v)
+          case 'n':
+            return decodeNum(v)
+          case 'N': {
+            switch(v[2]) {
+              case '+':
+              case '-':
+              case '0':
+                return decodeNum(v)
+            }
+            break
+          }
+          case 'a':
+            return decodeArray(values, v)
+        }
       }
+      return decodeStr(v)
   }
   return throwUnknownDataType(v)
 }

--- a/src/encode.ts
+++ b/src/encode.ts
@@ -11,20 +11,19 @@ export function encodeNum(num: number): string {
   if (Number.isNaN(num)) {
     return 'N|0'
   }
-  const a = 'n|' + num_to_s(num)
-  return a
-  // let b = num.toString()
-  // return a.length < b.length ? a : num
+  return 'n|' + num_to_s(num)
 }
 
 export function decodeNum(s: string): number {
-  switch (s) {
-    case 'N|+':
-      return Infinity
-    case 'N|-':
-      return -Infinity
-    case 'N|0':
-      return NaN
+  if (s.length === 3 && s[0] === 'N' && s[1] === '|') {
+    switch (s[2]) {
+      case '+':
+        return Infinity
+      case '-':
+        return -Infinity
+      case '0':
+        return NaN
+    }
   }
   s = s.replace('n|', '')
   return s_to_num(s)
@@ -35,34 +34,35 @@ export function decodeKey(key: Key): number {
 }
 
 export function encodeBool(b: boolean): string {
-  // return 'b|' + bool_to_s(b)
   return b ? 'b|T' : 'b|F'
 }
 
 export function decodeBool(s: string): boolean {
-  switch (s) {
-    case 'b|T':
-      return true
-    case 'b|F':
-      return false
+  if (s.length === 3 && s[0] === 'b' && s[1] === '|') {
+    switch (s[2]) {
+      case 'T':
+        return true
+      case 'F':
+        return false
+    }
   }
   return !!s
 }
 
 export function encodeStr(str: string): string {
-  const prefix = str[0] + str[1]
-  switch (prefix) {
-    case 'b|':
-    case 'o|':
-    case 'n|':
-    case 'a|':
-    case 's|':
-      str = 's|' + str
+  if (str[1] === '|') {
+    switch (str[0]) {
+      case 'b':
+      case 'o':
+      case 'n':
+      case 'a':
+      case 's':
+        return 's|' + str
+    }
   }
   return str
 }
 
 export function decodeStr(s: string): string {
-  const prefix = s[0] + s[1]
-  return prefix === 's|' ? s.substr(2) : s
+  return s[0] === 's' && s[1] === '|' ? s.substr(2) : s
 }


### PR DESCRIPTION
Currently, the encoding and decoding functions concat strings to then test these strings in switch statements.
After optimizing these function by working on the string directly, `encode` runs 10-20% faster while `decode` runs 30-40% faster.

Timings taken using an array containing 10000x 90kb of json. (`Array(10000).fill(<json>)`):
```
17/09/2025, 15:53:57: load test data: 2 milliseconds
17/09/2025, 15:53:57: prepare json string: 1.21 seconds
17/09/2025, 15:53:58: --------: instantly
17/09/2025, 15:53:58: compress-json[compress]: 2.76 seconds
17/09/2025, 15:54:01: save data/compress-json.json: 1 millisecond
17/09/2025, 15:54:01: compress-json[decompress]: 5.6 seconds
17/09/2025, 15:54:07: compress-json[compare]: 1.35 seconds
17/09/2025, 15:54:08: --------: instantly
17/09/2025, 15:54:08: optimized[compress]: 2.26 seconds
17/09/2025, 15:54:10: save data/optimized.json: instantly
17/09/2025, 15:54:10: optimized[decompress]: 3.5 seconds
17/09/2025, 15:54:14: optimized[compare]: 1.34 seconds
done.
```
Timings taken using an array containing 1000x 4.9mb of json. (`Array(1000).fill(<json>)`):
```
17/09/2025, 16:03:35: load test data: 23 milliseconds
17/09/2025, 16:03:35: prepare json string: 658 milliseconds
17/09/2025, 16:03:35: --------: instantly
17/09/2025, 16:03:35: compress-json[compress]: 1.66 seconds
17/09/2025, 16:03:37: save data/compress-json.json: 3 milliseconds
17/09/2025, 16:03:37: compress-json[decompress]: 3.27 seconds
17/09/2025, 16:03:40: compress-json[compare]: 726 milliseconds
17/09/2025, 16:03:41: --------: instantly
17/09/2025, 16:03:41: optimized[compress]: 1.43 seconds
17/09/2025, 16:03:42: save data/optimized.json: 4 milliseconds
17/09/2025, 16:03:42: optimized[decompress]: 2.28 seconds
17/09/2025, 16:03:45: optimized[compare]: 691 milliseconds
done.
```

_Tests modified to run both old and new code side-by-side_

